### PR TITLE
feat: inline prompt を廃止し prompt_ref 必須化 + Studio UI 修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 Yagra は、**YAML 定義から LangGraph の `StateGraph` を構築・実行**する Python ライブラリです。
-フロー制御（分岐・ループ）とノード設定（prompt/model など）をコードから分離し、
+フロー制御（分岐・ループ）とノード設定（prompt_ref/model など）をコードから分離し、
 `workflow.yaml` の差し替えだけで挙動を切り替えられます。
 
 ## Yagraでできること
@@ -91,8 +91,7 @@ nodes:
   - id: "faq_bot"
     handler: "answer_faq"
     params:
-      prompt:
-        system: "pricing response"
+      prompt_ref: "../prompts/support_prompts.yaml#faq"
   - id: "general_bot"
     handler: "answer_general"
     params:
@@ -184,7 +183,7 @@ yagra visualize \
 
 ### `yagra studio`（フォーム + DnD 編集 + 保存）
 
-Workflow の `prompt` / `model` / `condition` 編集に加え、DnD でノード追加・接続変更を行い、diff 確認・保存・rollback を実行するローカル WebUI/API を起動します。
+Workflow の `prompt_ref` / `model` / `condition` 編集に加え、DnD でノード追加・接続変更を行い、diff 確認・保存・rollback を実行するローカル WebUI/API を起動します。
 
 ```bash
 # ランチャー起動（UI で workflow を選択/新規作成）
@@ -210,7 +209,7 @@ Studio は同梱アセットをローカル配信するため、インターネ�
    - `prompt key` を指定した場合は `path#key` 形式になり、生成 YAML は `{ key: { system, user } }` 形式になります。
 4. Graph Canvas 上でノードをドラッグして位置調整し、右側ポート（output）から左側ポート（input）へドラッグしてエッジ追加（戻りループは下側 output → 上側 input で接続）
 5. 再接続時はエッジ端点をドラッグして接続先を変更（ドラッグ起点が新 source、ドロップ先が新 target）
-6. Node Properties で `node id`（リネーム）, `prompt_ref`, `Model Settings`（`provider` / `name` / `temperature` など）を設定
+6. Node Properties で `node id`（リネーム）, `prompt yaml` / `prompt key`, `Model Settings`（`provider` / `name` / `temperature` など）を設定
    - `node id` を変更して `Apply Node Edit` すると、関連する `edges[].source/target` と `start_at/end_at` も自動で同期されます。
 7. `Preview Diff` で変更差分と validation を確認
 8. `Save` で workflow を保存（backup 作成）
@@ -255,11 +254,12 @@ Studio は同梱アセットをローカル配信するため、インターネ�
 
 ### 2. prompt 参照解決の契約
 
+- プロンプトは `prompts/` 配下の外部 YAML ファイルに定義し、`prompt_ref` で参照します。
+- **`params.prompt`（インラインプロンプト）は廃止されました。** ワークフロー YAML に `params.prompt` が存在するとバリデーションエラーになります。
 - `prompt_ref` は実行前に解決されます。
 - handler が受け取る `params` には解決済み値が入ります。
   - `params["prompt"]`
   - `params["model"]`
-- `prompt_ref` と `prompt` を同時指定した場合、`prompt_ref` 解決結果に `prompt` が上書きマージされます（ノード側優先）。
 - 実行時に handler へ渡る `params` からは `prompt_ref` は除去されます（`prompt`/`model` を利用）。
 - `model_ref` は廃止です。モデル設定は `nodes[].params.model` にインライン定義します。
 - `prompt_ref` の参照形式:

--- a/docs/api/get-workflow-form.md
+++ b/docs/api/get-workflow-form.md
@@ -46,7 +46,7 @@ curl -X GET 'http://127.0.0.1:8787/api/workflow/form'
 | field | type | nullable | 説明 |
 | --- | --- | --- | --- |
 | revision | string | No | 現在リビジョン |
-| nodes | object[] | No | ノード編集項目（`id`,`handler`,`prompt_ref`,`prompt`,`model`） |
+| nodes | object[] | No | ノード編集項目（`id`,`handler`,`prompt_ref`,`model`） |
 | edges | object[] | No | エッジ編集項目（`index`,`source`,`target`,`condition`） |
 | prompt_catalog_keys | string[] | No | （Deprecated）prompt catalog候補キー |
 | workflow | object | No | workflow 生データ |
@@ -64,7 +64,6 @@ curl -X GET 'http://127.0.0.1:8787/api/workflow/form'
       "id": "planner",
       "handler": "planner_handler",
       "prompt_ref": "prompts/new_task.yaml#intent",
-      "prompt": null,
       "model": {"provider": "openai", "name": "gpt-4.1-mini", "temperature": 0.2}
     }
   ],
@@ -93,6 +92,7 @@ curl -X GET 'http://127.0.0.1:8787/api/workflow/form'
 - UIでは通常このAPIをロード起点として利用する。
 - Studio の現行運用では `prompt_catalog_keys` / `catalog_preview` は利用しない（後方互換のため返却）。
 - `model_ref` は廃止。モデル設定は `nodes[].params.model` のインライン定義を使用する。
+- `prompt`（インラインプロンプト）は廃止。プロンプトは `prompts/` 配下の YAML ファイルに定義し `prompt_ref` で参照する。
 
 ## 6. 実装同期メモ
 

--- a/docs/sphinx/source/quickstart.md
+++ b/docs/sphinx/source/quickstart.md
@@ -25,8 +25,7 @@ nodes:
   - id: "faq_bot"
     handler: "answer_faq"
     params:
-      prompt:
-        system: "pricing response"
+      prompt_ref: "../prompts/support_prompts.yaml#faq"
   - id: "general_bot"
     handler: "answer_general"
   - id: "finish"

--- a/examples/prompts/branch_prompts.yaml
+++ b/examples/prompts/branch_prompts.yaml
@@ -1,0 +1,3 @@
+planner:
+  system: "You are planner."
+  user: "Plan for: {goal}"

--- a/examples/workflows/branch-inline.yaml
+++ b/examples/workflows/branch-inline.yaml
@@ -12,9 +12,7 @@ nodes:
   - id: "planner"
     handler: "planner_handler"
     params:
-      prompt:
-        system: "You are planner."
-        user: "Plan for: {goal}"
+      prompt_ref: "../prompts/branch_prompts.yaml#planner"
       model:
         provider: "openai"
         name: "gpt-4.1-mini"

--- a/src/yagra/adapters/inbound/workflow_studio_server.py
+++ b/src/yagra/adapters/inbound/workflow_studio_server.py
@@ -935,20 +935,16 @@ def _studio_html() -> str:
                   v-model.trim="nodeEditor.promptKey"
                   type="text"
                   list="nodePromptKeyOptions"
-                  placeholder="intent"
+                  placeholder="default"
                   @change="onNodePromptKeyChange"
                 />
               </div>
               <div class="inline-row">
                 <div class="field">
-                  <label for="nodePromptRefInput">prompt_ref</label>
-                  <input
-                    id="nodePromptRefInput"
-                    v-model="nodeEditor.promptRef"
-                    type="text"
-                    placeholder="../prompts/review.yaml#intent"
-                    @change="onPromptRefChange"
-                  />
+                  <label>prompt_ref (auto)</label>
+                  <div class="mono hint" style="padding: 4px 0; min-height: 1.4em; word-break: break-all;">
+                    {{ nodeEditor.promptRef || "(auto create on Apply)" }}
+                  </div>
                 </div>
               </div>
               <div v-if="nodeEditor.promptFileParseError" class="hint danger">
@@ -1013,7 +1009,7 @@ def _studio_html() -> str:
                 </div>
               </div>
               <button type="button" class="secondary" @click="applyNodeEdit">Apply Node Edit</button>
-              <div class="hint">node id は空文字/重複不可です。prompt yaml 未選択で Apply すると workspace_root（project root）直下の `prompts/` 配下へ自動作成されます。prompt key を指定すると `path#key` で保存されます。</div>
+              <div class="hint">node id は空文字/重複不可です。prompt yaml 未選択で Apply すると prompts/ 配下へ自動作成されます。既存ファイル選択時は Apply でファイル内容を上書き更新します。prompt key を指定すると path#key で保存されます。</div>
             </template>
           </section>
 
@@ -1779,7 +1775,7 @@ def _studio_html() -> str:
           handler: "",
           promptFilePath: "",
           promptFileParseError: "",
-          promptKey: "",
+          promptKey: "default",
           promptKeyOptions: [],
           promptRef: "",
           promptSystem: "",
@@ -1841,7 +1837,7 @@ def _studio_html() -> str:
               nodeEditor.handler = "";
               nodeEditor.promptFilePath = "";
               nodeEditor.promptFileParseError = "";
-              nodeEditor.promptKey = "";
+              nodeEditor.promptKey = "default";
               nodeEditor.promptKeyOptions = [];
               nodeEditor.promptRef = "";
               nodeEditor.promptSystem = "";
@@ -1893,7 +1889,7 @@ def _studio_html() -> str:
             const refParts = splitPromptReference(nodeEditor.promptRef);
             const workspacePromptPath = promptRefPathToWorkspacePath(refParts.path);
             nodeEditor.promptFilePath = workspacePromptPath;
-            nodeEditor.promptKey = refParts.keyPath;
+            nodeEditor.promptKey = refParts.keyPath || "default";
             nodeEditor.promptFileParseError = "";
             if (workspacePromptPath) {
               void loadPromptFromYaml(workspacePromptPath, {
@@ -2212,7 +2208,7 @@ def _studio_html() -> str:
           nodeEditor.handler = "";
           nodeEditor.promptFilePath = "";
           nodeEditor.promptFileParseError = "";
-          nodeEditor.promptKey = "";
+          nodeEditor.promptKey = "default";
           nodeEditor.promptKeyOptions = [];
           nodeEditor.promptRef = "";
           nodeEditor.promptSystem = "";
@@ -2361,11 +2357,6 @@ def _studio_html() -> str:
                 x: Number.isFinite(x) ? x : fallbackPos.x,
                 y: Number.isFinite(y) ? y : fallbackPos.y,
               };
-              const promptObj = isRecord(formItem?.prompt)
-                ? deepClone(formItem.prompt)
-                : isRecord(params.prompt)
-                  ? deepClone(params.prompt)
-                  : null;
               const modelObj = isRecord(formItem?.model)
                 ? deepClone(formItem.model)
                 : isRecord(params.model)
@@ -2383,7 +2374,7 @@ def _studio_html() -> str:
                     : typeof params.prompt_ref === "string"
                       ? params.prompt_ref
                       : "",
-                  prompt: promptObj,
+                  prompt: null,
                   model: modelObj,
                   isStart: startIds.has(node.id),
                   isEnd: endIds.has(node.id),
@@ -2466,9 +2457,6 @@ def _studio_html() -> str:
             const promptRef = normalizeText(data.promptRef);
             if (promptRef) {
               params.prompt_ref = promptRef;
-            }
-            if (isRecord(data.prompt)) {
-              params.prompt = deepClone(data.prompt);
             }
             if (isRecord(data.model)) {
               params.model = deepClone(data.model);
@@ -2566,22 +2554,8 @@ def _studio_html() -> str:
               return;
             }
             const selectedData = isRecord(selectedNode.value.data) ? selectedNode.value.data : {};
-            const promptObj = isRecord(selectedData.prompt)
-              ? deepClone(selectedData.prompt)
-              : {};
             const promptSystem = normalizeText(nodeEditor.promptSystem);
             const promptUser = normalizeText(nodeEditor.promptUser);
-            if (promptSystem) {
-              promptObj.system = promptSystem;
-            } else {
-              delete promptObj.system;
-            }
-            if (promptUser) {
-              promptObj.user = promptUser;
-            } else {
-              delete promptObj.user;
-            }
-            const finalPrompt = Object.keys(promptObj).length > 0 ? promptObj : null;
             const promptKey = normalizePromptKeyPath(nodeEditor.promptKey);
             nodeEditor.promptKey = promptKey;
             let promptFilePath = normalizePosixPath(nodeEditor.promptFilePath);
@@ -2600,6 +2574,12 @@ def _studio_html() -> str:
               promptRef = buildPromptReference(promptRefPath, promptKey);
               nodeEditor.promptRef = promptRef;
             } else {
+              await savePromptToExistingFile(
+                promptFilePath,
+                promptSystem,
+                promptUser,
+                promptKey,
+              );
               const promptRefPath = workspacePathToPromptRefPath(promptFilePath) || promptFilePath;
               promptRef = buildPromptReference(promptRefPath, promptKey);
               nodeEditor.promptRef = promptRef;
@@ -2663,7 +2643,7 @@ def _studio_html() -> str:
                   id: nextNodeId,
                   handler: normalizeText(nodeEditor.handler),
                   promptRef,
-                  prompt: finalPrompt,
+                  prompt: null,
                   model: finalModel,
                 },
               };
@@ -3155,6 +3135,23 @@ def _studio_html() -> str:
             throw new Error(data.message || data.error || `yaml save failed: ${path}`);
           }
           throw new Error(`failed to allocate prompt yaml path under ${promptDirectory}/`);
+        }
+
+        async function savePromptToExistingFile(filePath, systemPrompt, userPrompt, promptKeyPath) {
+          const content = buildPromptYamlContent(systemPrompt, userPrompt, promptKeyPath);
+          const { response, data } = await requestJson("/api/studio/file/save", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              path: filePath,
+              content,
+              overwrite: true,
+            }),
+          });
+          if (!response.ok) {
+            throw new Error(data.message || data.error || `prompt file save failed: ${filePath}`);
+          }
+          return normalizeText(data.path) || filePath;
         }
 
         async function refreshStudioFiles() {

--- a/src/yagra/application/services/reference_resolver.py
+++ b/src/yagra/application/services/reference_resolver.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -73,6 +73,12 @@ def resolve_workflow_references(
                 location=("nodes", index, "params"),
             )
 
+        if "prompt" in node_params and node_params["prompt"] is not None:
+            raise WorkflowReferenceError(
+                "inline prompt is no longer supported; use prompt_ref to reference an external prompt file",
+                location=("nodes", index, "params", "prompt"),
+            )
+
         prompt_ref = _as_optional_string(
             node_params.get("prompt_ref"),
             location=("nodes", index, "params", "prompt_ref"),
@@ -85,22 +91,7 @@ def resolve_workflow_references(
                 ref_label="prompt_ref",
                 location=("nodes", index, "params", "prompt_ref"),
             )
-            prompt_override = _as_optional_mapping(
-                node_params.get("prompt"),
-                location=("nodes", index, "params", "prompt"),
-            )
-            if prompt_override is None:
-                node_params["prompt"] = resolved_prompt
-            else:
-                if not isinstance(resolved_prompt, Mapping):
-                    raise WorkflowReferenceError(
-                        "prompt_ref must resolve to a mapping when prompt override is provided",
-                        location=("nodes", index, "params", "prompt_ref"),
-                    )
-                node_params["prompt"] = _merge_mapping(
-                    base=deepcopy(dict(resolved_prompt)),
-                    override=prompt_override,
-                )
+            node_params["prompt"] = resolved_prompt
 
         if "model_ref" in node_params:
             raise WorkflowReferenceError(
@@ -276,23 +267,3 @@ def _as_optional_string(value: Any, location: Location = ()) -> str | None:
     if not normalized:
         return None
     return normalized
-
-
-def _as_optional_mapping(value: Any, location: Location = ()) -> dict[str, Any] | None:
-    """値を任意辞書として正規化する。"""
-    if value is None:
-        return None
-    if not isinstance(value, Mapping):
-        raise WorkflowReferenceError("override value must be a mapping", location=location)
-    return deepcopy(dict(value))
-
-
-def _merge_mapping(base: dict[str, Any], override: Mapping[str, Any]) -> dict[str, Any]:
-    """辞書を再帰マージし、override 側を優先する。"""
-    merged = deepcopy(base)
-    for key, value in override.items():
-        if key in merged and isinstance(merged[key], Mapping) and isinstance(value, Mapping):
-            merged[key] = _merge_mapping(dict(merged[key]), dict(value))
-            continue
-        merged[key] = deepcopy(value)
-    return merged

--- a/src/yagra/application/services/studio_service.py
+++ b/src/yagra/application/services/studio_service.py
@@ -740,7 +740,6 @@ def _node_form_item_to_dict(item: WorkflowNodeFormItem) -> dict[str, Any]:
         "id": item.id,
         "handler": item.handler,
         "prompt_ref": item.prompt_ref,
-        "prompt": item.prompt,
         "model": item.model,
     }
 

--- a/src/yagra/application/use_cases/workflow_form_model.py
+++ b/src/yagra/application/use_cases/workflow_form_model.py
@@ -21,7 +21,6 @@ class WorkflowNodeFormItem:
     id: str
     handler: str
     prompt_ref: str | None
-    prompt: dict[str, Any] | None
     model: dict[str, Any] | None
 
 
@@ -116,7 +115,6 @@ def build_workflow_form_view(
                 id=node_id,
                 handler=handler,
                 prompt_ref=_as_optional_string(params_mapping.get("prompt_ref")),
-                prompt=_as_optional_mapping(params_mapping.get("prompt")),
                 model=_as_optional_mapping(params_mapping.get("model")),
             )
         )

--- a/src/yagra/application/use_cases/workflow_form_patcher.py
+++ b/src/yagra/application/use_cases/workflow_form_patcher.py
@@ -114,7 +114,6 @@ def _apply_node_edits(nodes: list[Any], node_edits: Sequence[Mapping[str, Any]])
             raise ValueError(f"node params must be a mapping: {node_id}")
 
         _apply_optional_string_field(edit_mapping, params, "prompt_ref")
-        _apply_optional_mapping_field(edit_mapping, params, "prompt")
         _apply_optional_mapping_field(edit_mapping, params, "model")
 
 

--- a/tests/fixtures/prompts/branch_prompts.yaml
+++ b/tests/fixtures/prompts/branch_prompts.yaml
@@ -1,0 +1,3 @@
+planner:
+  system: "You are planner."
+  user: "Plan for: {goal}"

--- a/tests/fixtures/workflows/branch-inline.yaml
+++ b/tests/fixtures/workflows/branch-inline.yaml
@@ -12,9 +12,7 @@ nodes:
   - id: "planner"
     handler: "planner_handler"
     params:
-      prompt:
-        system: "You are planner."
-        user: "Plan for: {goal}"
+      prompt_ref: "prompts/branch_prompts.yaml#planner"
       model:
         provider: "openai"
         name: "gpt-4.1-mini"
@@ -32,4 +30,3 @@ edges:
     condition: "direct_answer"
   - source: "planner"
     target: "finish"
-

--- a/tests/integration/test_state_graph_builder.py
+++ b/tests/integration/test_state_graph_builder.py
@@ -201,7 +201,6 @@ def test_graphyml_from_workflow_normalizes_runtime_params_and_hides_ref_keys(
                         "handler": "inspect_handler",
                         "params": {
                             "prompt_ref": "prompts/support_prompts.yaml#planner",
-                            "prompt": {"system": "Override planner system prompt."},
                             "model": {
                                 "provider": "openai",
                                 "name": "gpt-4.1-mini",
@@ -248,9 +247,46 @@ def test_graphyml_from_workflow_normalizes_runtime_params_and_hides_ref_keys(
     )
 
     result = engine.invoke({})
-    assert result["prompt_system"] == "Override planner system prompt."
+    assert result["prompt_system"] == "You are planner."
     assert result["prompt_user"] == "Create a concise plan."
     assert result["model_name"] == "gpt-4.1-mini"
     assert result["model_temperature"] == 0.42
     assert result["kwargs_temperature"] == 0.1
     assert result["has_prompt_ref"] is False
+
+
+def test_graphyml_from_workflow_rejects_inline_prompt(tmp_path: Path) -> None:
+    workflow_path = tmp_path / "inline-prompt-rejected.yaml"
+    workflow_path.write_text(
+        yaml.safe_dump(
+            {
+                "version": "1.0",
+                "start_at": "start",
+                "end_at": ["start"],
+                "nodes": [
+                    {
+                        "id": "start",
+                        "handler": "start_handler",
+                        "params": {
+                            "prompt": {"system": "inline prompt"},
+                        },
+                    },
+                ],
+                "edges": [],
+                "params": {},
+            },
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+
+    def _start_handler(state: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        _ = params
+        return dict(state)
+
+    with pytest.raises(ValueError, match="inline prompt is no longer supported"):
+        Yagra.from_workflow(
+            workflow_path=workflow_path,
+            registry={"start_handler": _start_handler},
+        )

--- a/tests/integration/test_workflow_studio_api.py
+++ b/tests/integration/test_workflow_studio_api.py
@@ -634,6 +634,15 @@ def test_workflow_studio_api_supports_bootstrap_save_from_empty_workflow(
 
 def test_workflow_studio_form_preview_and_save(tmp_path: Path) -> None:
     workflow_path = _write_workflow(tmp_path / "workflow.yaml", _base_payload())
+    prompt_file_path = tmp_path / "prompts.yaml"
+    prompt_file_path.write_text(
+        yaml.safe_dump(
+            {"edited": {"system": "edited prompt", "user": "do something"}},
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
     backup_dir = tmp_path / ".yagra-backups"
 
     server = create_workflow_studio_server(
@@ -662,7 +671,7 @@ def test_workflow_studio_form_preview_and_save(tmp_path: Path) -> None:
                 "node_edits": [
                     {
                         "node_id": "planner",
-                        "prompt": {"system": "edited prompt"},
+                        "prompt_ref": f"{prompt_file_path.resolve()}#edited",
                         "model": {"provider": "openai", "name": "gpt-4.1-nano"},
                     }
                 ],
@@ -676,8 +685,8 @@ def test_workflow_studio_form_preview_and_save(tmp_path: Path) -> None:
         assert preview["summary"]["total"] >= 1
         assert preview["validation_report"]["is_valid"] is True
         assert (
-            preview["candidate_workflow"]["nodes"][1]["params"]["prompt"]["system"]
-            == "edited prompt"
+            preview["candidate_workflow"]["nodes"][1]["params"]["prompt_ref"]
+            == f"{prompt_file_path.resolve()}#edited"
         )
         assert preview["candidate_workflow"]["edges"][2]["condition"] == "done"
 
@@ -696,7 +705,7 @@ def test_workflow_studio_form_preview_and_save(tmp_path: Path) -> None:
         status, after_form = _request_json("GET", f"{base_url}/api/workflow/form")
         assert status == 200
         planner = next(item for item in after_form["nodes"] if item["id"] == "planner")
-        assert planner["prompt"]["system"] == "edited prompt"
+        assert planner["prompt_ref"] == f"{prompt_file_path.resolve()}#edited"
         assert planner["model"]["name"] == "gpt-4.1-nano"
     finally:
         server.shutdown()

--- a/tests/unit/application/test_workflow_form_model.py
+++ b/tests/unit/application/test_workflow_form_model.py
@@ -26,7 +26,6 @@ def _base_payload() -> dict[str, Any]:
                 "id": "planner",
                 "handler": "planner_handler",
                 "params": {
-                    "prompt": {"system": "You are planner.", "user": "Create a plan."},
                     "model": {"provider": "openai", "name": "gpt-4.1-mini"},
                 },
             },
@@ -68,8 +67,10 @@ def test_build_workflow_form_view_includes_path_based_prompt_ref() -> None:
     assert retry_edge.target == "planner"
 
 
-def test_build_workflow_form_view_handles_inline_prompt_and_model(tmp_path: Path) -> None:
-    workflow_path = _write_workflow(tmp_path / "inline.yaml", _base_payload())
+def test_build_workflow_form_view_handles_prompt_ref_and_model(tmp_path: Path) -> None:
+    payload = _base_payload()
+    payload["nodes"][1]["params"]["prompt_ref"] = "prompts/support_prompts.yaml#planner"
+    workflow_path = _write_workflow(tmp_path / "ref.yaml", payload)
     session = load_workflow_edit_session(workflow_path=workflow_path)
 
     view = build_workflow_form_view(
@@ -79,8 +80,7 @@ def test_build_workflow_form_view_handles_inline_prompt_and_model(tmp_path: Path
     )
 
     planner = next(item for item in view.nodes if item.id == "planner")
-    assert planner.prompt_ref is None
-    assert planner.prompt == {"system": "You are planner.", "user": "Create a plan."}
+    assert planner.prompt_ref == "prompts/support_prompts.yaml#planner"
     assert planner.model == {"provider": "openai", "name": "gpt-4.1-mini"}
     assert view.prompt_catalog_keys == ()
 

--- a/tests/unit/application/test_workflow_form_patcher.py
+++ b/tests/unit/application/test_workflow_form_patcher.py
@@ -20,7 +20,6 @@ def _base_payload() -> dict[str, Any]:
                 "handler": "planner_handler",
                 "params": {
                     "prompt_ref": "planner",
-                    "prompt": {"system": "old prompt"},
                     "model": {"provider": "openai", "name": "gpt-4.1-mini"},
                 },
             },
@@ -42,7 +41,6 @@ def test_apply_form_edits_updates_node_and_edge() -> None:
             {
                 "node_id": "planner",
                 "prompt_ref": "planner_v2",
-                "prompt": {"system": "new prompt"},
                 "model": {"provider": "openai", "name": "gpt-4.1-nano"},
             }
         ],
@@ -52,7 +50,6 @@ def test_apply_form_edits_updates_node_and_edge() -> None:
     assert patched is not workflow
     planner_params = patched["nodes"][1]["params"]
     assert planner_params["prompt_ref"] == "planner_v2"
-    assert planner_params["prompt"]["system"] == "new prompt"
     assert planner_params["model"]["name"] == "gpt-4.1-nano"
     assert patched["edges"][1]["condition"] == "done"
     assert workflow["edges"][1].get("condition") is None
@@ -66,7 +63,6 @@ def test_apply_form_edits_clears_optional_fields() -> None:
             {
                 "node_id": "planner",
                 "prompt_ref": "",
-                "prompt": None,
                 "model": None,
             }
         ],
@@ -75,7 +71,6 @@ def test_apply_form_edits_clears_optional_fields() -> None:
 
     planner_params = patched["nodes"][1]["params"]
     assert "prompt_ref" not in planner_params
-    assert "prompt" not in planner_params
     assert "model" not in planner_params
     assert "condition" not in patched["edges"][0]
 

--- a/tests/unit/application/test_workflow_validation_reporter.py
+++ b/tests/unit/application/test_workflow_validation_reporter.py
@@ -170,24 +170,24 @@ def test_load_validated_graph_spec_accepts_inline_model_mapping(tmp_path: Path) 
     assert model["max_tokens"] == 512
 
 
-def test_load_validated_graph_spec_merges_prompt_ref_with_prompt_overrides(tmp_path: Path) -> None:
+def test_load_validated_graph_spec_rejects_inline_prompt(tmp_path: Path) -> None:
     payload = _base_payload()
-    prompt_file = str((FIXTURES_ROOT / "prompts" / "support_prompts.yaml").resolve())
     payload["params"] = {}
     payload["nodes"][1]["params"] = {
-        "prompt_ref": f"{prompt_file}#planner",
         "prompt": {
-            "system": "You are planner (overridden).",
+            "system": "You are planner.",
+            "user": "Create a plan.",
         },
     }
-    workflow_path = _write_workflow(tmp_path / "prompt-merge.yaml", payload)
+    workflow_path = _write_workflow(tmp_path / "inline-prompt.yaml", payload)
 
-    spec = load_validated_graph_spec(workflow_path)
+    with pytest.raises(WorkflowValidationFailedError) as exc:
+        load_validated_graph_spec(workflow_path)
 
-    planner_node = next(node for node in spec.nodes if node.id == "planner")
-    prompt = planner_node.params["prompt"]
-    assert prompt["system"] == "You are planner (overridden)."
-    assert prompt["user"] == "Create a concise plan."
+    report = exc.value.report
+    assert report.is_valid is False
+    assert any(issue.code == "reference_error" for issue in report.issues)
+    assert any(issue.location == ("nodes", 1, "params", "prompt") for issue in report.issues)
 
 
 def test_load_validated_graph_spec_resolves_workspace_relative_prompt_ref_without_bundle_root(
@@ -243,17 +243,15 @@ def test_validate_workflow_for_ui_reports_error_when_model_ref_is_used(
     assert issue.location == ("nodes", 1, "params", "model_ref")
 
 
-def test_validate_workflow_for_ui_reports_error_when_prompt_override_is_not_mapping(
+def test_validate_workflow_for_ui_reports_error_when_inline_prompt_is_used(
     tmp_path: Path,
 ) -> None:
     payload = _base_payload()
-    prompt_file = str((FIXTURES_ROOT / "prompts" / "support_prompts.yaml").resolve())
     payload["params"] = {}
     payload["nodes"][1]["params"] = {
-        "prompt_ref": f"{prompt_file}#planner",
-        "prompt": "invalid",
+        "prompt": {"system": "inline prompt"},
     }
-    workflow_path = _write_workflow(tmp_path / "prompt-override-invalid.yaml", payload)
+    workflow_path = _write_workflow(tmp_path / "inline-prompt-error.yaml", payload)
 
     report = validate_workflow_for_ui(workflow_path)
 


### PR DESCRIPTION
## Summary

- workflow YAML の `params.prompt`（インラインプロンプト）を廃止し、`params.prompt_ref` による外部ファイル参照のみに統一
- Studio UI で新規ワークフロー作成時に `params.prompt` が生成されバリデーションエラーになる問題を修正
- `prompt_ref` 入力欄を読み取り専用の自動表示に変更（`prompt yaml` + `prompt key` から自動算出）
- 既存プロンプトファイル選択時も Apply でファイル内容を上書き保存するよう対応
- `prompt key` のデフォルト値を `"default"` に変更
- README / API docs / quickstart のドキュメントを新仕様に更新

### 破壊的変更

`params.prompt` を含む既存の workflow YAML はバリデーションエラーになります。`prompt_ref` による外部ファイル参照への移行が必要です。
