### PR TITLE
feat: UI ビジュアル品質と可読性を向上 (M-11)

### DIFF
--- a/docs/product/milestones.md
+++ b/docs/product/milestones.md
@@ -16,7 +16,7 @@
 | M-08 | G-05 | WebUI 上で prompt/model/条件のフォーム編集を可能にする | 非エンジニアがコード変更なしで主要設定を更新し、即時検証できる | Done |
 | M-09 | G-05 | WebUI 上で DnD によるノード追加・接続編集を実現する | ノード追加・接続変更・round-trip 検証が成立し、YAML 意味整合が維持される | Done |
 | M-10 | G-05 | UI 情報設計と操作導線を明確化する | Add Node / Connect / Rewire / Save の流れが画面上で理解でき、主要操作が座標手入力なしで完了できる | Done |
-| M-11 | G-05 | UI ビジュアル品質と可読性を向上する | レイアウト・配色・ラベル体系を改善し、重要情報の判別と誤操作防止が現状より向上する | Todo |
+| M-11 | G-05 | UI ビジュアル品質と可読性を向上する | レイアウト・配色・ラベル体系を改善し、重要情報の判別と誤操作防止が現状より向上する | Done |
 | M-12 | G-06 | JSON Schema 公開と validate CLI を整備する | `yagra schema export` で JSON Schema を出力でき、`yagra validate --format json` で構造化エラーを返却できる | Done |
 | M-13 | G-06 | テンプレートライブラリを整備する | `yagra init --template <name>` で典型パターン（branch, loop, rag 等）のスキャフォールドを生成できる | Todo |
 

--- a/docs/product/progress.md
+++ b/docs/product/progress.md
@@ -80,11 +80,11 @@
 | G05-I05 | prompt/model/条件をフォーム編集できるようにする | Done | `src/yagra/adapters/inbound/workflow_studio_server.py` |
 | G05-I06 | DnD でノード追加とエッジ接続変更を行い round-trip 整合を維持する | Done | `src/yagra/adapters/inbound/workflow_studio_server.py` |
 | G05-I07 | 主要操作の情報設計と導線を見直し、初見でも操作順が分かる UI にする | Done | `src/yagra/adapters/inbound/workflow_studio_server.py` |
-| G05-I08 | レイアウト/配色/ラベル体系を改善し、可読性と視認性を向上する | Todo | `docs/product/milestones.md` (M-11) |
+| G05-I08 | レイアウト/配色/ラベル体系を改善し、可読性と視認性を向上する | Done | `src/yagra/adapters/inbound/workflow_studio_server.py` (M-11) |
 
-- 完了済み: G05-I01, G05-I02, G05-I03, G05-I04, G05-I05, G05-I06, G05-I07
-- 未完了: G05-I08
-- 現在地: M-05〜M-10 で機能到達と主要操作導線の明確化は完了。次フェーズとして M-11（レイアウト/配色/ラベル体系の改善）に着手する。
+- 完了済み: G05-I01, G05-I02, G05-I03, G05-I04, G05-I05, G05-I06, G05-I07, G05-I08
+- 未完了: なし
+- 現在地: G-05 の全項目が完了。M-11 でツールバーグループ化、トースト通知、バリデーション/Diff の色分け表示、ノードプロパティのサブセクション化、ボタンのローディング状態管理、UIラベルの英語統一を実施済み。
 
 ### G-06: コーディングエージェントが Yagra ワークフローを正確に生成・検証できる
 

--- a/src/yagra/adapters/inbound/workflow_studio_server.py
+++ b/src/yagra/adapters/inbound/workflow_studio_server.py
@@ -338,6 +338,19 @@ def _studio_html() -> str:
       --accent: #0a6fd8;
       --danger: #c62828;
       --ok: #2e7d32;
+      --warn: #e65100;
+      --diff-add: #e6ffed;
+      --diff-add-text: #1b5e20;
+      --diff-del: #ffeef0;
+      --diff-del-text: #b71c1c;
+      --diff-meta: #f0f4ff;
+      --diff-meta-text: #1565c0;
+      --toast-success: #2e7d32;
+      --toast-error: #c62828;
+      --subsection-bg: #f8fafd;
+      --subsection-border: #e4ecf5;
+      --save-bg: #d32f2f;
+      --save-border: #b71c1c;
     }
     * {
       box-sizing: border-box;
@@ -396,10 +409,30 @@ def _studio_html() -> str:
       padding: 8px 12px;
       font-weight: 700;
       cursor: pointer;
+      transition: opacity 120ms ease;
+    }
+    button:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
     }
     button.secondary {
       background: #fff;
       color: var(--accent);
+    }
+    button.save-btn {
+      background: var(--save-bg);
+      border-color: var(--save-border);
+      color: #fff;
+    }
+    .btn-group {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
+    .btn-group + .btn-group {
+      margin-left: 4px;
+      padding-left: 10px;
+      border-left: 1px solid var(--line);
     }
     input[type="text"], select, textarea {
       border: 1px solid var(--line);
@@ -532,6 +565,148 @@ def _studio_html() -> str:
       color: var(--ok);
       font-weight: 700;
     }
+    .toast-container {
+      position: fixed;
+      top: 14px;
+      right: 14px;
+      z-index: 9999;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      pointer-events: none;
+    }
+    .toast-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      border-radius: 10px;
+      font-size: 13px;
+      font-weight: 600;
+      color: #fff;
+      background: var(--toast-success);
+      box-shadow: 0 4px 14px rgba(0,0,0,0.18);
+      pointer-events: auto;
+      animation: toastIn 220ms ease;
+      max-width: 480px;
+      word-break: break-word;
+    }
+    .toast-item.is-error {
+      background: var(--toast-error);
+    }
+    .toast-item.is-fading {
+      opacity: 0;
+      transition: opacity 350ms ease;
+    }
+    @keyframes toastIn {
+      from { opacity: 0; transform: translateX(20px); }
+      to { opacity: 1; transform: translateX(0); }
+    }
+    .validation-list {
+      display: grid;
+      gap: 6px;
+      margin: 8px 0 0;
+    }
+    .validation-pass {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 12px;
+      border-radius: 8px;
+      background: #e8f5e9;
+      color: var(--ok);
+      font-size: 13px;
+      font-weight: 700;
+    }
+    .validation-issue {
+      display: flex;
+      gap: 8px;
+      align-items: flex-start;
+      padding: 8px 10px;
+      border-radius: 8px;
+      background: var(--diff-del);
+      font-size: 12px;
+      line-height: 1.45;
+    }
+    .issue-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px 7px;
+      border-radius: 4px;
+      background: var(--danger);
+      color: #fff;
+      font-size: 10px;
+      font-weight: 800;
+      letter-spacing: 0.03em;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .issue-msg {
+      color: var(--text);
+    }
+    .issue-location {
+      font-family: "Menlo", "Monaco", "Consolas", monospace;
+      font-size: 11px;
+      color: var(--muted);
+    }
+    .diff-display {
+      width: 100%;
+      min-height: 170px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 10px;
+      font-family: "Menlo", "Monaco", "Consolas", monospace;
+      font-size: 12px;
+      line-height: 1.55;
+      background: #fff;
+      overflow: auto;
+      margin: 8px 0 0;
+    }
+    .diff-line-add {
+      background: var(--diff-add);
+      color: var(--diff-add-text);
+      display: block;
+      padding: 0 4px;
+      border-radius: 2px;
+    }
+    .diff-line-del {
+      background: var(--diff-del);
+      color: var(--diff-del-text);
+      display: block;
+      padding: 0 4px;
+      border-radius: 2px;
+    }
+    .diff-line-meta {
+      background: var(--diff-meta);
+      color: var(--diff-meta-text);
+      display: block;
+      padding: 0 4px;
+      border-radius: 2px;
+      font-weight: 700;
+    }
+    .diff-line-ctx {
+      display: block;
+      padding: 0 4px;
+      color: var(--muted);
+    }
+    .subsection-label {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 11px;
+      font-weight: 800;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      padding: 6px 0 2px;
+      border-top: 1px solid var(--subsection-border);
+      margin-top: 4px;
+    }
+    .subsection-label:first-child {
+      border-top: none;
+      margin-top: 0;
+      padding-top: 0;
+    }
     .workflow-node {
       position: relative;
       min-width: 180px;
@@ -648,22 +823,37 @@ def _studio_html() -> str:
 </head>
 <body>
   <div id="app" class="page" :class="{ 'is-connecting': isConnecting }">
+    <div class="toast-container">
+      <div
+        v-for="toast in toasts"
+        :key="toast.id"
+        class="toast-item"
+        :class="{ 'is-error': toast.isError, 'is-fading': toast.fading }"
+      >{{ toast.message }}</div>
+    </div>
     <section class="header">
       <h1>Yagra Workflow Studio</h1>
-      <div class="muted">Vue 3 + Vue Flow (CDN / ES Modules / no-build)</div>
       <div class="toolbar">
         <template v-if="hasTarget">
-          <button type="button" @click="loadWorkflow">Load</button>
-          <button type="button" class="secondary" @click="previewDiff">Preview Diff</button>
-          <button type="button" @click="saveWorkflow">Save</button>
-          <input
-            v-model.trim="backupId"
-            type="text"
-            placeholder="rollback backup_id"
-            style="max-width: 360px;"
-          />
-          <button type="button" class="secondary" @click="rollbackWorkflow">Rollback</button>
-          <button type="button" class="secondary" @click="openLauncher">Change Target</button>
+          <div class="btn-group">
+            <button type="button" :disabled="isBusy" @click="loadWorkflow">Load</button>
+            <button type="button" class="secondary" :disabled="isBusy" @click="previewDiff">Preview Diff</button>
+          </div>
+          <div class="btn-group">
+            <button type="button" class="save-btn" :disabled="isBusy" @click="saveWorkflow">{{ isBusy ? 'Saving...' : 'Save' }}</button>
+          </div>
+          <div class="btn-group">
+            <input
+              v-model.trim="backupId"
+              type="text"
+              placeholder="backup_id"
+              style="max-width: 280px;"
+            />
+            <button type="button" class="secondary" :disabled="isBusy" @click="rollbackWorkflow">Rollback</button>
+          </div>
+          <div class="btn-group">
+            <button type="button" class="secondary" :disabled="isBusy" @click="openLauncher">Change Target</button>
+          </div>
         </template>
         <template v-else>
           <button type="button" @click="refreshStudioFiles">Refresh Files</button>
@@ -672,7 +862,6 @@ def _studio_html() -> str:
       <div class="meta-line">
         <span class="muted">target: {{ studioTargetPath || "-" }}</span>
         <span class="muted">revision: {{ revision || "-" }}</span>
-        <span :class="statusClass">status: {{ status.message }}</span>
       </div>
     </section>
 
@@ -709,7 +898,7 @@ def _studio_html() -> str:
           </div>
           <label class="check-item">
             <input v-model="launcher.overwrite" type="checkbox" />
-            <span>既存 workflow を上書きする（overwrite）</span>
+            <span>Overwrite existing workflow</span>
           </label>
           <div class="toolbar">
             <button type="button" @click="createStudioTarget">Create And Open</button>
@@ -727,7 +916,7 @@ def _studio_html() -> str:
           <div class="section-head">
             <h2>Graph Canvas</h2>
             <div class="hint">
-              ノードをクリックすると右サイドバーに編集フォームが表示されます。通常は右→左、戻りループは下→上ハンドルで接続できます。
+              Click a node to edit properties in the sidebar. Connect nodes via right/left handles; loop edges use bottom/top handles.
             </div>
           </div>
           <div class="flow-shell">
@@ -787,7 +976,7 @@ def _studio_html() -> str:
             <div class="field">
               <label>end_at</label>
               <div v-if="nodeIdOptions.length === 0" class="hint">
-                先にノードを追加してください。
+                Add nodes first.
               </div>
               <div v-else class="check-list">
                 <label v-for="nodeId in nodeIdOptions" :key="'end-' + nodeId" class="check-item">
@@ -801,7 +990,7 @@ def _studio_html() -> str:
                 </label>
               </div>
             </div>
-            <div class="hint">`start_at` と `end_at` は保存時に workflow へ反映されます。</div>
+            <div class="hint"><code>start_at</code> and <code>end_at</code> are applied to the workflow on save.</div>
           </section>
 
           <section class="side-section">
@@ -817,16 +1006,18 @@ def _studio_html() -> str:
               </div>
             </div>
             <button type="button" class="secondary" @click="addNode">Add Node</button>
-            <div class="hint">追加後の位置は自動配置されます。必要に応じてキャンバス上でドラッグしてください。</div>
+            <div class="hint">Nodes are auto-positioned. Drag on canvas to reposition.</div>
           </section>
 
           <section class="side-section">
             <h2>Node Properties</h2>
             <div v-if="!selectedNode" class="hint">
-              ノードを選択してください。
+              Select a node to edit its properties.
             </div>
             <template v-else>
               <div class="mono">selected: {{ selectedNode.id }}</div>
+
+              <div class="subsection-label">Basic Info</div>
               <div class="field">
                 <label for="nodeIdInput">node id</label>
                 <input id="nodeIdInput" v-model.trim="nodeEditor.id" type="text" />
@@ -835,6 +1026,8 @@ def _studio_html() -> str:
                 <label for="nodeHandlerInput">handler</label>
                 <input id="nodeHandlerInput" v-model="nodeEditor.handler" type="text" />
               </div>
+
+              <div class="subsection-label">Prompt Settings</div>
               <div class="field">
                 <label for="nodePromptFileSelect">prompt yaml</label>
                 <select
@@ -859,12 +1052,10 @@ def _studio_html() -> str:
                   @change="onNodePromptKeyChange"
                 />
               </div>
-              <div class="inline-row">
-                <div class="field">
-                  <label>prompt_ref (auto)</label>
-                  <div class="mono hint" style="padding: 4px 0; min-height: 1.4em; word-break: break-all;">
-                    {{ nodeEditor.promptRef || "(auto create on Apply)" }}
-                  </div>
+              <div class="field">
+                <label>prompt_ref (auto)</label>
+                <div class="mono hint" style="padding: 4px 0; min-height: 1.4em; word-break: break-all;">
+                  {{ nodeEditor.promptRef || "(auto create on Apply)" }}
                 </div>
               </div>
               <div v-if="nodeEditor.promptFileParseError" class="hint danger">
@@ -886,57 +1077,67 @@ def _studio_html() -> str:
                   placeholder="{{input}}"
                 ></textarea>
               </div>
-              <div class="field">
-                <label>Model Settings</label>
-                <div class="inline-row">
+
+              <div class="subsection-label">Model Settings</div>
+              <div class="inline-row">
+                <div class="field">
+                  <label for="nodeModelProviderInput">provider</label>
                   <input
                     id="nodeModelProviderInput"
                     v-model.trim="nodeEditor.modelProvider"
                     type="text"
-                    placeholder="provider (e.g. openai)"
+                    placeholder="e.g. openai"
                   />
+                </div>
+                <div class="field">
+                  <label for="nodeModelNameInput">model name</label>
                   <input
                     id="nodeModelNameInput"
                     v-model.trim="nodeEditor.modelName"
                     type="text"
-                    placeholder="name (e.g. gpt-4.1-mini)"
+                    placeholder="e.g. gpt-4.1-mini"
                   />
                 </div>
               </div>
-              <div class="field">
-                <label>Model Runtime Params</label>
-                <div class="inline-row">
+              <div class="inline-row">
+                <div class="field">
+                  <label for="nodeModelTemperatureInput">temperature</label>
                   <input
                     id="nodeModelTemperatureInput"
                     v-model.trim="nodeEditor.temperature"
                     type="text"
-                    placeholder="temperature (e.g. 0.2)"
+                    placeholder="e.g. 0.2"
                   />
+                </div>
+                <div class="field">
+                  <label for="nodeModelTopPInput">top_p</label>
                   <input
                     id="nodeModelTopPInput"
                     v-model.trim="nodeEditor.topP"
                     type="text"
-                    placeholder="top_p (e.g. 0.9)"
-                  />
-                </div>
-                <div class="field">
-                  <input
-                    id="nodeModelMaxTokensInput"
-                    v-model.trim="nodeEditor.maxTokens"
-                    type="text"
-                    placeholder="max_tokens (e.g. 512)"
+                    placeholder="e.g. 0.9"
                   />
                 </div>
               </div>
-              <button type="button" class="secondary" @click="applyNodeEdit">Apply Node Edit</button>
-              <div class="hint">node id は空文字/重複不可です。prompt yaml 未選択で Apply すると prompts/ 配下へ自動作成されます。既存ファイル選択時は Apply でファイル内容を上書き更新します。prompt key を指定すると path#key で保存されます。</div>
+              <div class="field">
+                <label for="nodeModelMaxTokensInput">max_tokens</label>
+                <input
+                  id="nodeModelMaxTokensInput"
+                  v-model.trim="nodeEditor.maxTokens"
+                  type="text"
+                  placeholder="e.g. 512"
+                />
+              </div>
+
+              <button type="button" class="secondary" :disabled="isBusy" @click="applyNodeEdit">Apply Node Edit</button>
+              <div class="hint">Node id must be unique and non-empty. If no prompt yaml is selected, a file is auto-created under prompts/ on Apply. Use prompt key for path#key references.</div>
             </template>
           </section>
 
           <section class="side-section">
             <h2>Edge Properties</h2>
             <div v-if="!selectedEdge" class="hint">
-              エッジを選択すると condition を編集できます。エッジ端点をドラッグすると再接続できます。
+              Select an edge to edit its condition. Drag edge endpoints to rewire connections.
             </div>
             <template v-else>
               <div class="mono">
@@ -947,7 +1148,7 @@ def _studio_html() -> str:
                 <label for="edgeConditionInput">condition</label>
                 <input id="edgeConditionInput" v-model="edgeEditor.condition" type="text" placeholder="retry / done" />
               </div>
-              <button type="button" class="secondary" @click="applyEdgeEdit">Apply Edge Edit</button>
+              <button type="button" class="secondary" :disabled="isBusy" @click="applyEdgeEdit">Apply Edge Edit</button>
             </template>
           </section>
 
@@ -957,11 +1158,32 @@ def _studio_html() -> str:
       <section class="lower">
         <article class="panel">
           <h2>Validation</h2>
-          <pre>{{ validationText }}</pre>
+          <div v-if="validationData.isValid" class="validation-list">
+            <div class="validation-pass">Validation passed</div>
+          </div>
+          <div v-else-if="validationData.issues.length > 0" class="validation-list">
+            <div v-for="(issue, idx) in validationData.issues" :key="'vi-' + idx" class="validation-issue">
+              <span class="issue-badge">{{ issue.code }}</span>
+              <span class="issue-msg">{{ issue.message }}</span>
+              <span v-if="issue.location" class="issue-location">@ {{ issue.location }}</span>
+            </div>
+          </div>
+          <div v-else class="validation-list">
+            <div class="hint">No validation data yet. Load or preview to validate.</div>
+          </div>
         </article>
         <article class="panel">
           <h2>Diff</h2>
-          <pre>{{ diffText }}</pre>
+          <div v-if="diffLines.length > 0" class="diff-display">
+            <span
+              v-for="(line, idx) in diffLines"
+              :key="'dl-' + idx"
+              :class="line.cls"
+            >{{ line.text }}</span>
+          </div>
+          <div v-else class="diff-display" style="color: var(--muted);">
+            Click "Preview Diff" to see changes.
+          </div>
         </article>
       </section>
     </template>
@@ -1635,6 +1857,21 @@ def _studio_html() -> str:
       return lines.join("\\n");
     }
 
+    function parseValidationReport(report) {
+      if (!report) {
+        return { isValid: false, issues: [], empty: true };
+      }
+      if (report.is_valid) {
+        return { isValid: true, issues: [], empty: false };
+      }
+      const issues = (report.issues || []).map(issue => ({
+        code: issue.code || "UNKNOWN",
+        message: issue.message || "",
+        location: issue.location ? JSON.stringify(issue.location) : "",
+      }));
+      return { isValid: false, issues, empty: false };
+    }
+
     function buildDiffText(data) {
       const summary = isRecord(data.summary) ? data.summary : {};
       return [
@@ -1643,6 +1880,28 @@ def _studio_html() -> str:
         "yaml diff:",
         data.yaml_unified_diff || "(no yaml changes)",
       ].join("\\n");
+    }
+
+    function parseDiffLines(data) {
+      const summary = isRecord(data.summary) ? data.summary : {};
+      const headerLine = `summary: total=${summary.total || 0}, nodes=${summary.nodes || 0}, edges=${summary.edges || 0}, params=${summary.params || 0}`;
+      const rawDiff = data.yaml_unified_diff || "";
+      const lines = [
+        { text: headerLine + "\\n", cls: "diff-line-meta" },
+        { text: "\\n", cls: "diff-line-ctx" },
+      ];
+      if (!rawDiff) {
+        lines.push({ text: "(no yaml changes)\\n", cls: "diff-line-ctx" });
+        return lines;
+      }
+      for (const line of rawDiff.split("\\n")) {
+        let cls = "diff-line-ctx";
+        if (line.startsWith("+")) cls = "diff-line-add";
+        else if (line.startsWith("-")) cls = "diff-line-del";
+        else if (line.startsWith("@@")) cls = "diff-line-meta";
+        lines.push({ text: line + "\\n", cls });
+      }
+      return lines;
     }
 
     createApp({
@@ -1659,6 +1918,11 @@ def _studio_html() -> str:
         const status = reactive({ message: "idle", isError: false });
         const validationText = ref("-");
         const diffText = ref("");
+        const isBusy = ref(false);
+        const toasts = ref([]);
+        let toastCounter = 0;
+        const validationData = reactive({ isValid: false, issues: [], empty: true });
+        const diffLines = ref([]);
         const hasTarget = ref(false);
         const showLauncher = ref(false);
         const studioTargetPath = ref("");
@@ -1837,6 +2101,22 @@ def _studio_html() -> str:
         function setStatus(message, isError = false) {
           status.message = message;
           status.isError = isError;
+          if (message && message !== "idle") {
+            showToast(message, isError);
+          }
+        }
+
+        function showToast(message, isError = false) {
+          toastCounter += 1;
+          const id = toastCounter;
+          const toast = reactive({ id, message, isError, fading: false });
+          toasts.value = [...toasts.value, toast];
+          setTimeout(() => {
+            toast.fading = true;
+            setTimeout(() => {
+              toasts.value = toasts.value.filter(t => t.id !== id);
+            }, 400);
+          }, 3000);
         }
 
         function parseOptionalNumber(raw, label) {
@@ -3101,21 +3381,26 @@ def _studio_html() -> str:
             setStatus("open target is required", true);
             return;
           }
+          isBusy.value = true;
           setStatus(`opening: ${workflowPath} ...`);
-          const { response, data } = await requestJson("/api/studio/open", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ workflow_path: workflowPath }),
-          });
-          if (!response.ok) {
-            setStatus(data.message || data.error || "open failed", true);
-            return;
+          try {
+            const { response, data } = await requestJson("/api/studio/open", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ workflow_path: workflowPath }),
+            });
+            if (!response.ok) {
+              setStatus(data.message || data.error || "open failed", true);
+              return;
+            }
+            await loadStudioTarget();
+            await loadStudioFiles();
+            showLauncher.value = false;
+            await loadWorkflow();
+            setStatus(`opened: ${workflowPath}`);
+          } finally {
+            isBusy.value = false;
           }
-          await loadStudioTarget();
-          await loadStudioFiles();
-          showLauncher.value = false;
-          await loadWorkflow();
-          setStatus(`opened: ${workflowPath}`);
         }
 
         async function createStudioTarget() {
@@ -3124,62 +3409,77 @@ def _studio_html() -> str:
             setStatus("create target path is required", true);
             return;
           }
+          isBusy.value = true;
           setStatus(`creating: ${workflowPath} ...`);
-          const { response, data } = await requestJson("/api/studio/create", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              workflow_path: workflowPath,
-              overwrite: Boolean(launcher.overwrite),
-            }),
-          });
-          if (!response.ok) {
-            setStatus(data.message || data.error || "create failed", true);
-            return;
+          try {
+            const { response, data } = await requestJson("/api/studio/create", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                workflow_path: workflowPath,
+                overwrite: Boolean(launcher.overwrite),
+              }),
+            });
+            if (!response.ok) {
+              setStatus(data.message || data.error || "create failed", true);
+              return;
+            }
+            launcher.openWorkflowPath = workflowPath;
+            await loadStudioTarget();
+            await loadStudioFiles();
+            showLauncher.value = false;
+            await loadWorkflow();
+            setStatus(`created: ${workflowPath}`);
+          } finally {
+            isBusy.value = false;
           }
-          launcher.openWorkflowPath = workflowPath;
-          await loadStudioTarget();
-          await loadStudioFiles();
-          showLauncher.value = false;
-          await loadWorkflow();
-          setStatus(`created: ${workflowPath}`);
         }
 
         async function loadWorkflow() {
+          isBusy.value = true;
           setStatus("loading...");
-          const { response, data } = await requestJson("/api/workflow/form");
-          if (response.status === 409 && data.error === "studio_target_required") {
-            resetEditorState();
-            hasTarget.value = false;
-            showLauncher.value = true;
-            await loadStudioTarget();
-            await loadStudioFiles();
-            setStatus("workflow target を選択してください");
-            return;
-          }
-          if (!response.ok) {
-            setStatus(data.message || data.error || "load failed", true);
-            return;
-          }
-          hasTarget.value = true;
-          showLauncher.value = false;
+          try {
+            const { response, data } = await requestJson("/api/workflow/form");
+            if (response.status === 409 && data.error === "studio_target_required") {
+              resetEditorState();
+              hasTarget.value = false;
+              showLauncher.value = true;
+              await loadStudioTarget();
+              await loadStudioFiles();
+              setStatus("Select a workflow target");
+              return;
+            }
+            if (!response.ok) {
+              setStatus(data.message || data.error || "load failed", true);
+              return;
+            }
+            hasTarget.value = true;
+            showLauncher.value = false;
 
-          revision.value = typeof data.revision === "string" ? data.revision : null;
-          originalWorkflow.value = isRecord(data.workflow) ? deepClone(data.workflow) : {};
-          baseUiState.value = isRecord(data.ui_state) ? deepClone(data.ui_state) : {};
+            revision.value = typeof data.revision === "string" ? data.revision : null;
+            originalWorkflow.value = isRecord(data.workflow) ? deepClone(data.workflow) : {};
+            baseUiState.value = isRecord(data.ui_state) ? deepClone(data.ui_state) : {};
 
-          nodes.value = buildNodesFromPayload(data.workflow, data.ui_state, data.nodes);
-          workflowMeta.version = normalizeText(data.workflow?.version) || "1.0";
-          workflowMeta.startAt = resolveWorkflowStartAt(data.workflow?.start_at);
-          workflowMeta.endAt = normalizeNodeIdList(data.workflow?.end_at);
-          onWorkflowMetaChange();
-          edges.value = buildEdgesFromPayload(data.workflow, data.ui_state, data.edges, nodes.value);
-          refreshEdgeMetadata();
-          selectedNodeId.value = null;
-          selectedEdgeId.value = null;
-          validationText.value = buildValidationText(data.validation_report);
-          diffText.value = "";
-          setStatus("loaded");
+            nodes.value = buildNodesFromPayload(data.workflow, data.ui_state, data.nodes);
+            workflowMeta.version = normalizeText(data.workflow?.version) || "1.0";
+            workflowMeta.startAt = resolveWorkflowStartAt(data.workflow?.start_at);
+            workflowMeta.endAt = normalizeNodeIdList(data.workflow?.end_at);
+            onWorkflowMetaChange();
+            edges.value = buildEdgesFromPayload(data.workflow, data.ui_state, data.edges, nodes.value);
+            refreshEdgeMetadata();
+            selectedNodeId.value = null;
+            selectedEdgeId.value = null;
+            validationText.value = buildValidationText(data.validation_report);
+            const vd = parseValidationReport(data.validation_report);
+            validationData.isValid = vd.isValid;
+            validationData.issues = vd.issues;
+            validationData.empty = vd.empty;
+            diffText.value = "";
+            diffLines.value = [];
+            setStatus("loaded");
+          } finally {
+            isBusy.value = false;
+          }
         }
 
         async function previewDiff() {
@@ -3187,37 +3487,47 @@ def _studio_html() -> str:
             setStatus("load first", true);
             return;
           }
+          isBusy.value = true;
           setStatus("previewing...");
-          const response = await fetch("/api/workflow/diff", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              workflow: buildWorkflowPayload(),
-              ui_state: buildUiStatePayload(),
-              base_revision: revision.value,
-            }),
-          });
-          const data = await response.json();
-          if (response.status === 409) {
-            if (data.error === "studio_target_required") {
-              resetEditorState();
-              hasTarget.value = false;
-              showLauncher.value = true;
-              await loadStudioTarget();
-              await loadStudioFiles();
-              setStatus("workflow target を選択してください");
+          try {
+            const response = await fetch("/api/workflow/diff", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                workflow: buildWorkflowPayload(),
+                ui_state: buildUiStatePayload(),
+                base_revision: revision.value,
+              }),
+            });
+            const data = await response.json();
+            if (response.status === 409) {
+              if (data.error === "studio_target_required") {
+                resetEditorState();
+                hasTarget.value = false;
+                showLauncher.value = true;
+                await loadStudioTarget();
+                await loadStudioFiles();
+                setStatus("Select a workflow target");
+                return;
+              }
+              setStatus("revision conflict. reload required", true);
               return;
             }
-            setStatus("revision conflict. reload required", true);
-            return;
+            if (!response.ok) {
+              setStatus(data.message || data.error || "diff failed", true);
+              return;
+            }
+            validationText.value = buildValidationText(data.validation_report);
+            const vd = parseValidationReport(data.validation_report);
+            validationData.isValid = vd.isValid;
+            validationData.issues = vd.issues;
+            validationData.empty = vd.empty;
+            diffText.value = buildDiffText(data);
+            diffLines.value = parseDiffLines(data);
+            setStatus("diff ready");
+          } finally {
+            isBusy.value = false;
           }
-          if (!response.ok) {
-            setStatus(data.message || data.error || "diff failed", true);
-            return;
-          }
-          validationText.value = buildValidationText(data.validation_report);
-          diffText.value = buildDiffText(data);
-          setStatus("diff ready");
         }
 
         async function saveWorkflow() {
@@ -3225,43 +3535,52 @@ def _studio_html() -> str:
             setStatus("load first", true);
             return;
           }
+          isBusy.value = true;
           setStatus("saving...");
-          const response = await fetch("/api/workflow/save", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              workflow: buildWorkflowPayload(),
-              ui_state: buildUiStatePayload(),
-              base_revision: revision.value,
-            }),
-          });
-          const data = await response.json();
-          if (response.status === 409) {
-            if (data.error === "studio_target_required") {
-              resetEditorState();
-              hasTarget.value = false;
-              showLauncher.value = true;
-              await loadStudioTarget();
-              await loadStudioFiles();
-              setStatus("workflow target を選択してください");
+          try {
+            const response = await fetch("/api/workflow/save", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                workflow: buildWorkflowPayload(),
+                ui_state: buildUiStatePayload(),
+                base_revision: revision.value,
+              }),
+            });
+            const data = await response.json();
+            if (response.status === 409) {
+              if (data.error === "studio_target_required") {
+                resetEditorState();
+                hasTarget.value = false;
+                showLauncher.value = true;
+                await loadStudioTarget();
+                await loadStudioFiles();
+                setStatus("Select a workflow target");
+                return;
+              }
+              setStatus("revision conflict. reload required", true);
               return;
             }
-            setStatus("revision conflict. reload required", true);
-            return;
+            if (response.status === 422) {
+              validationText.value = buildValidationText(data.report);
+              const vd = parseValidationReport(data.report);
+              validationData.isValid = vd.isValid;
+              validationData.issues = vd.issues;
+              validationData.empty = vd.empty;
+              setStatus("validation failed", true);
+              return;
+            }
+            if (!response.ok) {
+              setStatus(data.message || data.error || "save failed", true);
+              return;
+            }
+            revision.value = data.saved_revision;
+            backupId.value = data.backup_id || "";
+            await loadWorkflow();
+            setStatus(`saved (backup: ${data.backup_id})`);
+          } finally {
+            isBusy.value = false;
           }
-          if (response.status === 422) {
-            validationText.value = buildValidationText(data.report);
-            setStatus("validation failed", true);
-            return;
-          }
-          if (!response.ok) {
-            setStatus(data.message || data.error || "save failed", true);
-            return;
-          }
-          revision.value = data.saved_revision;
-          backupId.value = data.backup_id || "";
-          await loadWorkflow();
-          setStatus(`saved (backup: ${data.backup_id})`);
         }
 
         async function rollbackWorkflow() {
@@ -3271,43 +3590,48 @@ def _studio_html() -> str:
             return;
           }
           const shouldProceed = window.confirm(
-            "rollback を実行すると現在状態が復元先へ置き換わります。続行しますか？",
+            "Rollback will replace the current state with the backup. Continue?",
           );
           if (!shouldProceed) {
             setStatus("rollback cancelled");
             return;
           }
+          isBusy.value = true;
           setStatus("rolling back...");
-          const response = await fetch("/api/workflow/rollback", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ backup_id: targetBackupId }),
-          });
-          const data = await response.json();
-          if (response.status === 409 && data.error === "studio_target_required") {
-            resetEditorState();
-            hasTarget.value = false;
-            showLauncher.value = true;
-            await loadStudioTarget();
-            await loadStudioFiles();
-            setStatus("workflow target を選択してください");
-            return;
+          try {
+            const response = await fetch("/api/workflow/rollback", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ backup_id: targetBackupId }),
+            });
+            const data = await response.json();
+            if (response.status === 409 && data.error === "studio_target_required") {
+              resetEditorState();
+              hasTarget.value = false;
+              showLauncher.value = true;
+              await loadStudioTarget();
+              await loadStudioFiles();
+              setStatus("Select a workflow target");
+              return;
+            }
+            if (!response.ok) {
+              setStatus(data.message || data.error || "rollback failed", true);
+              return;
+            }
+            revision.value = data.restored_revision;
+            const safetyBackupId = normalizeText(data.safety_backup_id);
+            if (safetyBackupId) {
+              backupId.value = safetyBackupId;
+            }
+            await loadWorkflow();
+            if (safetyBackupId) {
+              setStatus(`rolled back (${targetBackupId}), safety backup: ${safetyBackupId}`);
+              return;
+            }
+            setStatus(`rolled back (${targetBackupId})`);
+          } finally {
+            isBusy.value = false;
           }
-          if (!response.ok) {
-            setStatus(data.message || data.error || "rollback failed", true);
-            return;
-          }
-          revision.value = data.restored_revision;
-          const safetyBackupId = normalizeText(data.safety_backup_id);
-          if (safetyBackupId) {
-            backupId.value = safetyBackupId;
-          }
-          await loadWorkflow();
-          if (safetyBackupId) {
-            setStatus(`rolled back (${targetBackupId}), safety backup: ${safetyBackupId}`);
-            return;
-          }
-          setStatus(`rolled back (${targetBackupId})`);
         }
 
         onMounted(async () => {
@@ -3323,7 +3647,7 @@ def _studio_html() -> str:
           }
           resetEditorState();
           showLauncher.value = true;
-          setStatus("workflow target を選択してください");
+          setStatus("Select a workflow target");
         });
 
         return {
@@ -3333,6 +3657,10 @@ def _studio_html() -> str:
           statusClass,
           validationText,
           diffText,
+          isBusy,
+          toasts,
+          validationData,
+          diffLines,
           hasTarget,
           showLauncher,
           studioTargetPath,


### PR DESCRIPTION
## Summary
- ツールバーのボタンを操作種別ごとにグループ化し、Save を赤色で破壊的操作として視覚的に区別
- ステータス表示をトースト風通知（成功=緑 / エラー=赤、3秒後フェードアウト）に変更
- バリデーション結果をエラーコードバッジ付きの構造化表示に改善
- Diff 表示に追加行(緑) / 削除行(赤) / メタ行(青) の色分けを適用
- ノードプロパティを Basic Info / Prompt Settings / Model Settings にサブセクション化
- API 通信中のボタン無効化（isBusy）で二重送信を防止
- UI ラベルを英語に統一
- プロダクトドキュメント更新（M-11 → Done, G05-I08 → Done）

## Test plan
- [x] `pytest` 全69テスト通過
- [x] `mypy` 型チェック通過
- [x] `ruff` lint/format 通過
- [x] pre-commit / pre-push フック通過
- [x] ブラウザ手動確認: ツールバーグループ化表示
- [x] ブラウザ手動確認: トースト通知の表示・フェードアウト
- [x] ブラウザ手動確認: バリデーションのバッジ付き色分け表示
- [x] ブラウザ手動確認: Diff の追加/削除/メタ行の色分け
- [x] ブラウザ手動確認: ノードプロパティのサブセクション分割

🤖 Generated with [Claude Code](https://claude.com/claude-code)