### PR TITLE
fix(mcp): remove top-level oneOf from inputSchema to fix Claude RC compatibility

### DIFF
--- a/src/yagra/adapters/inbound/mcp_server.py
+++ b/src/yagra/adapters/inbound/mcp_server.py
@@ -62,11 +62,17 @@ def create_mcp_server() -> Any:
                     "properties": {
                         "yaml_content": {
                             "type": "string",
-                            "description": "The Yagra workflow YAML string to validate",
+                            "description": (
+                                "The Yagra workflow YAML string to validate. "
+                                "Provide either this or workflow_path (not both)."
+                            ),
                         },
                         "workflow_path": {
                             "type": "string",
-                            "description": "Absolute or CWD-relative path to the workflow YAML file.",
+                            "description": (
+                                "Absolute or CWD-relative path to the workflow YAML file. "
+                                "Provide either this or yaml_content (not both)."
+                            ),
                         },
                         "base_dir": {
                             "type": "string",
@@ -77,10 +83,6 @@ def create_mcp_server() -> Any:
                             ),
                         },
                     },
-                    "oneOf": [
-                        {"required": ["yaml_content"]},
-                        {"required": ["workflow_path"]},
-                    ],
                 },
             ),
             Tool(
@@ -99,11 +101,17 @@ def create_mcp_server() -> Any:
                     "properties": {
                         "yaml_content": {
                             "type": "string",
-                            "description": "The Yagra workflow YAML string to analyze",
+                            "description": (
+                                "The Yagra workflow YAML string to analyze. "
+                                "Provide either this or workflow_path (not both)."
+                            ),
                         },
                         "workflow_path": {
                             "type": "string",
-                            "description": "Absolute or CWD-relative path to the workflow YAML file.",
+                            "description": (
+                                "Absolute or CWD-relative path to the workflow YAML file. "
+                                "Provide either this or yaml_content (not both)."
+                            ),
                         },
                         "base_dir": {
                             "type": "string",
@@ -114,10 +122,6 @@ def create_mcp_server() -> Any:
                             ),
                         },
                     },
-                    "oneOf": [
-                        {"required": ["yaml_content"]},
-                        {"required": ["workflow_path"]},
-                    ],
                 },
             ),
             Tool(


### PR DESCRIPTION
## 問題

Claude RC（Remote Control）経由でYagraのMCPツールを呼び出すと HTTP 400 が返り、ツールが使用できない状態になっていた。

**エラーメッセージ:**
```
input_schema does not support oneOf, allOf, or anyOf at the top level
```

## 原因

`validate_workflow` と `explain_workflow` の `inputSchema` トップレベルに `oneOf` を使って「`yaml_content` か `workflow_path` のどちらか必須」を表現していた。Claude RC の JSON Schema パーサーはトップレベルの `oneOf`/`allOf`/`anyOf` をサポートしていないため、ツール定義の読み込み段階で 400 エラーになっていた。

## 修正内容

- `validate_workflow` と `explain_workflow` の `inputSchema` から `oneOf` 制約を削除
- 両フィールドの `description` に「どちらか一方を指定する」旨を追記

## なぜ安全か

ランタイム側のハンドラー（`_tool_validate_workflow`, `_tool_explain_workflow`）は、どちらのフィールドも指定されていない場合に適切な構造化エラーを返す実装がすでにある。スキーマレベルの制約がなくても、動作の正確性は保たれる。

## テスト

```
63 passed, 2 skipped
```

既存テストがすべてパス。

## Checklist
- [x] バグの根本原因を特定・修正
- [x] 既存テストがすべてパス
- [x] 後方互換性あり（ランタイム動作は変わらない）